### PR TITLE
auditd configuration on Ubuntu 20.04 is partly not applied

### DIFF
--- a/hardening-linux-server/vars/main.yml
+++ b/hardening-linux-server/vars/main.yml
@@ -272,8 +272,8 @@ system_events:
   - "-a always,exit -F arch=b64 -S clock_settime -k time-change"
   - "-w /etc/localtime -p wa -k time-change"
   # Connection of external device (storage)
-  - "-a always,exit -F arch=b64 -S mount -F auid>=1000 -F auid!=4294967295 -k mounts"
-  - "-a always,exit -F arch=b64 -S mount -F auid>=500 -F auid!=4294967295 -k export"
+  - "-a always,exit -F arch=b64 -S mount -F \"auid>=1000\" -F auid!=4294967295 -k mounts"
+  - "-a always,exit -F arch=b64 -S mount -F \"auid>=500\" -F auid!=4294967295 -k export"
   # Loading/unloading of kernel modules
   - "-w /sbin/insmod -p x -k modules"
   - "-w /sbin/rmmod -p x -k modules"
@@ -294,9 +294,9 @@ access_events:
   - "-w /etc/sudoers.d -p wa -k scope"
   - "-w /var/log/sudo.log -p wa -k actions"
   # Modification of discretionary access control permissions
-  - "-a always,exit -F arch=b64 -S chmod -S fchmod -S fchmodat -F auid>=1000 -F auid!=4294967295 -k perm_mod"
-  - "-a always,exit -F arch=b64 -S chown -S fchown -S fchownat -S lchown -F auid>=1000 -F auid!=4294967295 -k perm_mod"
-  - "-a always,exit -F arch=b64 -S setxattr -S lsetxattr -S fsetxattr -S removexattr -S lremovexattr -S fremovexattr -F auid>=1000 -F auid!=4294967295 -k perm_mod"
+  - "-a always,exit -F arch=b64 -S chmod -S fchmod -S fchmodat -F \"auid>=1000\" -F auid!=4294967295 -k perm_mod"
+  - "-a always,exit -F arch=b64 -S chown -S fchown -S fchownat -S lchown -F \"auid>=1000\" -F auid!=4294967295 -k perm_mod"
+  - "-a always,exit -F arch=b64 -S setxattr -S lsetxattr -S fsetxattr -S removexattr -S lremovexattr -S fremovexattr -F \"auid>=1000\" -F auid!=4294967295 -k perm_mod"
 
 # Req-34: Account and Group Management events must be logged.
 config_account_group_mgmt_events: "{{ config_req_34 | default(true) }}"


### PR DESCRIPTION
Greater than '>' is interpreted as redirect operator that leads to error "-F missing operation for auid" and configuration not being applied.