### PR TITLE
Update linux(01)basic-hardening.yml

### DIFF
--- a/hardening-linux-server/tasks/linux(01)basic-hardening.yml
+++ b/hardening-linux-server/tasks/linux(01)basic-hardening.yml
@@ -624,7 +624,7 @@
 # Req-24: Authentication must be used for single user mode.
 
 - name: req-024.1 check if password for root user is set
-  shell: awk -F":" '($1 == "root" && $2 == "[!*]") {print $1}' /etc/shadow
+  shell: awk -F":" '($1 == "root" && $2 ~ "[!*]") {print $1}' /etc/shadow
   register: check_root_pw
   changed_when: check_root_pw.stdout != ""
   check_mode: no


### PR DESCRIPTION
Awk command in Req. 24 uses "==" to compare password to a regular expression, should be the "~" operator. Otherwise the comparison will always fail.