### PR TITLE
Update sshdconfig.j2

### DIFF
--- a/hardening-ssh/templates/sshdconfig.j2
+++ b/hardening-ssh/templates/sshdconfig.j2
@@ -71,7 +71,11 @@ MaxStartups {{max_startups}}
 PubkeyAuthentication {{ 'yes' if (pubkey_auth|bool) else 'no' }}
 {% endif %}
 
-AuthorizedKeysFile .ssh/authorized_keys
+AuthorizedKeysFile {{authkeys_file}}
+{% if config_authkeys_cmd %}
+AuthorizedKeysCommand {{authkeys_cmd}}
+AuthorizedKeysCommandUser {{authkeys_cmd_usr}}
+{% endif %}
 
 {% if config_ignore_rhost %}
 IgnoreRhosts {{ 'yes' if (ignore_rhosts|bool) else 'no' }}


### PR DESCRIPTION
Added optional variables that allow:
- different location of AuthorizedKeysFile (on modern Ubuntu servers this is /etc/ssh/authroized_keys/%u)
- ability to add AuthorizedKeysCommand (allowing SSH keys to be extracted from a directory)