### PR TITLE
Skip unowned-files check for /var/lib/docker

### DIFF
--- a/hardening-linux-server/tasks/linux(06)compliance-checks.yml
+++ b/hardening-linux-server/tasks/linux(06)compliance-checks.yml
@@ -244,7 +244,7 @@
 #         exist.
 
 - name: req-065.1 search for unowned files
-  shell: df --local -P | awk {'if (NR!=1) print $6'} | xargs -I '{}' find '{}' -xdev -nouser
+  shell: df --local -P | awk {'if (NR!=1) print $6'} | xargs -I '{}' find '{}' -xdev -nouser | grep -v '^/var/lib/docker'
   register: find_unowned
   changed_when: false
   check_mode: no
@@ -261,7 +261,7 @@
     - find_unowned.stdout != ""
 
 - name: req-065.3 search for files without group
-  shell: df --local -P | awk {'if (NR!=1) print $6'} | xargs -I '{}' find '{}' -xdev -nogroup
+  shell: df --local -P | awk {'if (NR!=1) print $6'} | xargs -I '{}' find '{}' -xdev -nogroup | grep -v '^/var/lib/docker'
   register: find_no_group
   changed_when: false
   check_mode: no

--- a/hardening-linux-server/tasks/linux(06)compliance-checks.yml
+++ b/hardening-linux-server/tasks/linux(06)compliance-checks.yml
@@ -244,7 +244,7 @@
 #         exist.
 
 - name: req-065.1 search for unowned files
-  shell: df --local -P | awk {'if (NR!=1) print $6'} | xargs -I '{}' find '{}' -xdev -nouser | grep -v '^/var/lib/docker'
+  shell: df --local -P | awk {'if (NR!=1) print $6'} | xargs -I '{}' find '{}' -xdev -nouser ! -path "/var/lib/docker/*"
   register: find_unowned
   changed_when: false
   check_mode: no
@@ -261,7 +261,7 @@
     - find_unowned.stdout != ""
 
 - name: req-065.3 search for files without group
-  shell: df --local -P | awk {'if (NR!=1) print $6'} | xargs -I '{}' find '{}' -xdev -nogroup | grep -v '^/var/lib/docker'
+  shell: df --local -P | awk {'if (NR!=1) print $6'} | xargs -I '{}' find '{}' -xdev -nogroup ! -path "/var/lib/docker/*"
   register: find_no_group
   changed_when: false
   check_mode: no


### PR DESCRIPTION
Docker uses different namespaces and thus UID/GID present in a container might not be present on the host, causing a (most of the time) false compliance violation for Req. 65